### PR TITLE
fix missing mp3s

### DIFF
--- a/hugo/content/posts/ctocast-guest.md
+++ b/hugo/content/posts/ctocast-guest.md
@@ -2,7 +2,7 @@
 title = "В гостях у CTOcast"
 date = "2015-04-21T14:57:00"
 categories = ["podcast"]
-filename = "CTOcast9_Umputun"
+filename = "http://traffic.libsyn.com/ctocast/CTOcast9_Umputun.mp3"
 +++
 
 

--- a/hugo/content/posts/dima-v-gostjah.md
+++ b/hugo/content/posts/dima-v-gostjah.md
@@ -2,6 +2,7 @@
 title = "Дима в гостях у меня, или наоборот"
 date = "2012-09-05T14:04:00"
 categories = ["podcast"]
+filename = "http://uwp.rucast.net/uwp-ypp.mp3"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/dima-umputun.jpg)

--- a/hugo/content/posts/opiat-vniezapno-ia-v-ghostiakh.md
+++ b/hugo/content/posts/opiat-vniezapno-ia-v-ghostiakh.md
@@ -2,6 +2,7 @@
 title = "Опять внезапно я в гостях"
 date = "2012-12-02T15:16:00"
 categories = ["others", "podcast"]
+filename = "http://www.airsimmer.org/simoman/svoboda_12_02_2012.mp3"
 +++
 
 

--- a/hugo/content/posts/podcast-1.md
+++ b/hugo/content/posts/podcast-1.md
@@ -2,6 +2,7 @@
 title = "Выпуск 1"
 date = "2005-07-05T09:05:00"
 categories = ["podcast"]
+filename = "ump_podcast1"
 +++
 
 

--- a/hugo/content/posts/podcast-10.md
+++ b/hugo/content/posts/podcast-10.md
@@ -2,6 +2,7 @@
 title = "Выпуск 10"
 date = "2005-08-23T15:13:00"
 categories = ["podcast"]
+filename = "ump_podcast10"
 +++
 
 

--- a/hugo/content/posts/podcast-100.md
+++ b/hugo/content/posts/podcast-100.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 100"
 date = "2006-11-22T21:37:00"
 categories = ["podcast"]
+filename = "ump_podcast100"
 +++
 
 

--- a/hugo/content/posts/podcast-101.md
+++ b/hugo/content/posts/podcast-101.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 101"
 date = "2006-12-01T05:05:00"
 categories = ["podcast"]
+filename = "ump_podcast101"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp101.gif)

--- a/hugo/content/posts/podcast-102.md
+++ b/hugo/content/posts/podcast-102.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 102"
 date = "2006-12-07T04:06:00"
 categories = ["podcast"]
+filename = "ump_podcast102"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp102.jpg)

--- a/hugo/content/posts/podcast-103.md
+++ b/hugo/content/posts/podcast-103.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 103"
 date = "2006-12-13T20:28:00"
 categories = ["podcast"]
+filename = "ump_podcast103"
 +++
 
 

--- a/hugo/content/posts/podcast-104.md
+++ b/hugo/content/posts/podcast-104.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 104"
 date = "2006-12-22T14:09:00"
 categories = ["podcast"]
+filename = "ump_podcast104"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp104.jpg)

--- a/hugo/content/posts/podcast-105.md
+++ b/hugo/content/posts/podcast-105.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 105"
 date = "2006-12-27T23:15:00"
 categories = ["podcast"]
+filename = "ump_podcast105"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp105.jpg)

--- a/hugo/content/posts/podcast-106.md
+++ b/hugo/content/posts/podcast-106.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 106"
 date = "2007-01-03T16:02:00"
 categories = ["podcast"]
+filename = "ump_podcast106"
 +++
 
 

--- a/hugo/content/posts/podcast-107.md
+++ b/hugo/content/posts/podcast-107.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 107"
 date = "2007-01-10T16:57:00"
 categories = ["podcast"]
+filename = "ump_podcast107"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp107.jpg)

--- a/hugo/content/posts/podcast-108.md
+++ b/hugo/content/posts/podcast-108.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 108"
 date = "2007-01-18T21:24:00"
 categories = ["podcast"]
+filename = "ump_podcast108"
 +++
 
 

--- a/hugo/content/posts/podcast-109.md
+++ b/hugo/content/posts/podcast-109.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 109"
 date = "2007-01-25T21:50:00"
 categories = ["podcast"]
+filename = "ump_podcast109"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp109.jpg)

--- a/hugo/content/posts/podcast-11.md
+++ b/hugo/content/posts/podcast-11.md
@@ -2,6 +2,7 @@
 title = "Выпуск 11"
 date = "2005-08-26T15:14:00"
 categories = ["podcast"]
+filename = "ump_podcast11"
 +++
 
 

--- a/hugo/content/posts/podcast-110.md
+++ b/hugo/content/posts/podcast-110.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 110"
 date = "2007-01-31T21:19:00"
 categories = ["podcast"]
+filename = "ump_podcast110"
 +++
 
 

--- a/hugo/content/posts/podcast-111.md
+++ b/hugo/content/posts/podcast-111.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 111"
 date = "2007-02-08T22:08:00"
 categories = ["podcast"]
+filename = "ump_podcast111"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp111.jpg)

--- a/hugo/content/posts/podcast-112.md
+++ b/hugo/content/posts/podcast-112.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 112"
 date = "2007-02-16T17:19:00"
 categories = ["podcast"]
+filename = "ump_podcast112"
 +++
 
 

--- a/hugo/content/posts/podcast-113.md
+++ b/hugo/content/posts/podcast-113.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 113"
 date = "2007-02-22T13:25:00"
 categories = ["podcast"]
+filename = "ump_podcast113"
 +++
 
 

--- a/hugo/content/posts/podcast-114.md
+++ b/hugo/content/posts/podcast-114.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 114"
 date = "2007-03-02T14:16:00"
 categories = ["podcast"]
+filename = "ump_podcast114"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp114.jpg)

--- a/hugo/content/posts/podcast-115.md
+++ b/hugo/content/posts/podcast-115.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 115"
 date = "2007-03-08T16:17:00"
 categories = ["podcast"]
+filename = "ump_podcast115"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp115.gif)

--- a/hugo/content/posts/podcast-116.md
+++ b/hugo/content/posts/podcast-116.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 116"
 date = "2007-03-15T13:39:00"
 categories = ["podcast"]
+filename = "ump_podcast116"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp116.jpg)

--- a/hugo/content/posts/podcast-117.md
+++ b/hugo/content/posts/podcast-117.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 117"
 date = "2007-03-21T17:54:00"
 categories = ["podcast"]
+filename = "ump_podcast117"
 +++
 
 

--- a/hugo/content/posts/podcast-118.md
+++ b/hugo/content/posts/podcast-118.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 118"
 date = "2007-03-30T14:19:00"
 categories = ["podcast"]
+filename = "ump_podcast118"
 +++
 
 

--- a/hugo/content/posts/podcast-119.md
+++ b/hugo/content/posts/podcast-119.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 119"
 date = "2007-04-04T16:35:00"
 categories = ["podcast"]
+filename = "ump_podcast119"
 +++
 
 

--- a/hugo/content/posts/podcast-12.md
+++ b/hugo/content/posts/podcast-12.md
@@ -2,6 +2,7 @@
 title = "Выпуск 12"
 date = "2005-08-29T15:18:00"
 categories = ["podcast"]
+filename = "ump_podcast12"
 +++
 
 

--- a/hugo/content/posts/podcast-120.md
+++ b/hugo/content/posts/podcast-120.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 120"
 date = "2007-04-12T17:29:00"
 categories = ["podcast"]
+filename = "ump_podcast120"
 +++
 
 

--- a/hugo/content/posts/podcast-121.md
+++ b/hugo/content/posts/podcast-121.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 121"
 date = "2007-04-19T17:42:00"
 categories = ["podcast"]
+filename = "ump_podcast121"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp121.jpg)

--- a/hugo/content/posts/podcast-122.md
+++ b/hugo/content/posts/podcast-122.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 122"
 date = "2007-04-26T17:18:00"
 categories = ["podcast"]
+filename = "ump_podcast122"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp122.jpg)

--- a/hugo/content/posts/podcast-123.md
+++ b/hugo/content/posts/podcast-123.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 123"
 date = "2007-05-04T12:21:00"
 categories = ["podcast"]
+filename = "ump_podcast123"
 +++
 
 

--- a/hugo/content/posts/podcast-124.md
+++ b/hugo/content/posts/podcast-124.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 124"
 date = "2007-05-11T10:35:00"
 categories = ["podcast"]
+filename = "ump_podcast124"
 +++
 
 

--- a/hugo/content/posts/podcast-125.md
+++ b/hugo/content/posts/podcast-125.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 125"
 date = "2007-05-17T18:51:00"
 categories = ["podcast"]
+filename = "ump_podcast125"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp125.jpg)

--- a/hugo/content/posts/podcast-126.md
+++ b/hugo/content/posts/podcast-126.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 126"
 date = "2007-05-25T16:57:00"
 categories = ["podcast"]
+filename = "ump_podcast126"
 +++
 
 

--- a/hugo/content/posts/podcast-127.md
+++ b/hugo/content/posts/podcast-127.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 127"
 date = "2007-06-01T16:52:00"
 categories = ["podcast"]
+filename = "ump_podcast127"
 +++
 
 

--- a/hugo/content/posts/podcast-128.md
+++ b/hugo/content/posts/podcast-128.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 128"
 date = "2007-06-08T18:28:00"
 categories = ["podcast"]
+filename = "ump_podcast128"
 +++
 
 

--- a/hugo/content/posts/podcast-129.md
+++ b/hugo/content/posts/podcast-129.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 129"
 date = "2007-06-15T16:37:00"
 categories = ["podcast"]
+filename = "ump_podcast129"
 +++
 
 

--- a/hugo/content/posts/podcast-13.md
+++ b/hugo/content/posts/podcast-13.md
@@ -2,6 +2,7 @@
 title = "Выпуск 13"
 date = "2005-09-01T18:23:00"
 categories = ["podcast"]
+filename = "ump_podcast13"
 +++
 
 

--- a/hugo/content/posts/podcast-130.md
+++ b/hugo/content/posts/podcast-130.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 130"
 date = "2007-06-21T13:26:00"
 categories = ["podcast"]
+filename = "ump_podcast130"
 +++
 
 

--- a/hugo/content/posts/podcast-131.md
+++ b/hugo/content/posts/podcast-131.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 131"
 date = "2007-06-28T16:41:00"
 categories = ["podcast"]
+filename = "ump_podcast131"
 +++
 
 

--- a/hugo/content/posts/podcast-132.md
+++ b/hugo/content/posts/podcast-132.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 132"
 date = "2007-07-06T20:21:00"
 categories = ["podcast"]
+filename = "ump_podcast132"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp132.jpg)

--- a/hugo/content/posts/podcast-133.md
+++ b/hugo/content/posts/podcast-133.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 133"
 date = "2007-07-11T17:49:00"
 categories = ["podcast"]
+filename = "ump_podcast133"
 +++
 
 

--- a/hugo/content/posts/podcast-134.md
+++ b/hugo/content/posts/podcast-134.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 134"
 date = "2007-07-20T18:49:00"
 categories = ["podcast"]
+filename = "ump_podcast134"
 +++
 
 

--- a/hugo/content/posts/podcast-135.md
+++ b/hugo/content/posts/podcast-135.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 135"
 date = "2007-07-28T16:33:00"
 categories = ["podcast"]
+filename = "ump_podcast135"
 +++
 
 

--- a/hugo/content/posts/podcast-136.md
+++ b/hugo/content/posts/podcast-136.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 136"
 date = "2007-08-02T16:15:00"
 categories = ["podcast"]
+filename = "ump_podcast136"
 +++
 
 

--- a/hugo/content/posts/podcast-137.md
+++ b/hugo/content/posts/podcast-137.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 137"
 date = "2007-08-10T17:38:00"
 categories = ["podcast"]
+filename = "ump_podcast137"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp137.jpg)

--- a/hugo/content/posts/podcast-138.md
+++ b/hugo/content/posts/podcast-138.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 138"
 date = "2007-08-16T18:58:00"
 categories = ["podcast"]
+filename = "ump_podcast138"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp138.gif)

--- a/hugo/content/posts/podcast-139.md
+++ b/hugo/content/posts/podcast-139.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 139"
 date = "2007-08-23T20:52:00"
 categories = ["podcast"]
+filename = "ump_podcast139"
 +++
 
 

--- a/hugo/content/posts/podcast-14.md
+++ b/hugo/content/posts/podcast-14.md
@@ -2,6 +2,7 @@
 title = "Выпуск 14"
 date = "2005-09-06T14:05:00"
 categories = ["podcast"]
+filename = "ump_podcast14"
 +++
 
 

--- a/hugo/content/posts/podcast-140.md
+++ b/hugo/content/posts/podcast-140.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 140"
 date = "2007-08-31T17:20:00"
 categories = ["podcast"]
+filename = "ump_podcast140"
 +++
 
 

--- a/hugo/content/posts/podcast-141.md
+++ b/hugo/content/posts/podcast-141.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 141"
 date = "2007-09-06T17:44:00"
 categories = ["podcast"]
+filename = "ump_podcast141"
 +++
 
 

--- a/hugo/content/posts/podcast-142.md
+++ b/hugo/content/posts/podcast-142.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 142"
 date = "2007-09-15T21:06:00"
 categories = ["podcast"]
+filename = "ump_podcast142"
 +++
 
 

--- a/hugo/content/posts/podcast-143.md
+++ b/hugo/content/posts/podcast-143.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 143"
 date = "2007-09-21T16:40:00"
 categories = ["podcast"]
+filename = "ump_podcast143"
 +++
 
 

--- a/hugo/content/posts/podcast-144.md
+++ b/hugo/content/posts/podcast-144.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 144"
 date = "2007-09-27T20:18:00"
 categories = ["podcast"]
+filename = "ump_podcast144"
 +++
 
 

--- a/hugo/content/posts/podcast-145.md
+++ b/hugo/content/posts/podcast-145.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 145"
 date = "2007-10-05T21:09:00"
 categories = ["podcast"]
+filename = "ump_podcast145"
 +++
 
 

--- a/hugo/content/posts/podcast-146.md
+++ b/hugo/content/posts/podcast-146.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 146"
 date = "2007-10-12T18:27:00"
 categories = ["podcast"]
+filename = "ump_podcast146"
 +++
 
 

--- a/hugo/content/posts/podcast-147.md
+++ b/hugo/content/posts/podcast-147.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 147"
 date = "2007-10-17T16:16:00"
 categories = ["podcast"]
+filename = "ump_podcast147"
 +++
 
 

--- a/hugo/content/posts/podcast-148.md
+++ b/hugo/content/posts/podcast-148.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 148"
 date = "2007-10-25T18:31:00"
 categories = ["podcast"]
+filename = "ump_podcast148"
 +++
 
 

--- a/hugo/content/posts/podcast-149.md
+++ b/hugo/content/posts/podcast-149.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 149"
 date = "2007-11-01T15:50:00"
 categories = ["podcast"]
+filename = "ump_podcast149"
 +++
 
 

--- a/hugo/content/posts/podcast-15.md
+++ b/hugo/content/posts/podcast-15.md
@@ -2,6 +2,7 @@
 title = "Выпуск 15"
 date = "2005-09-10T17:10:00"
 categories = ["podcast"]
+filename = "ump_podcast15"
 +++
 
 

--- a/hugo/content/posts/podcast-150.md
+++ b/hugo/content/posts/podcast-150.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 150"
 date = "2007-11-08T14:17:00"
 categories = ["podcast"]
+filename = "ump_podcast150"
 +++
 
 

--- a/hugo/content/posts/podcast-151.md
+++ b/hugo/content/posts/podcast-151.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 151"
 date = "2007-11-16T17:33:00"
 categories = ["podcast"]
+filename = "ump_podcast151"
 +++
 
 

--- a/hugo/content/posts/podcast-152.md
+++ b/hugo/content/posts/podcast-152.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 152"
 date = "2007-11-23T15:50:00"
 categories = ["podcast"]
+filename = "ump_podcast152"
 +++
 
 

--- a/hugo/content/posts/podcast-153.md
+++ b/hugo/content/posts/podcast-153.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 153"
 date = "2007-11-30T16:38:00"
 categories = ["podcast"]
+filename = "ump_podcast153"
 +++
 
 

--- a/hugo/content/posts/podcast-154.md
+++ b/hugo/content/posts/podcast-154.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 154"
 date = "2007-12-07T19:33:00"
 categories = ["podcast"]
+filename = "ump_podcast154"
 +++
 
 

--- a/hugo/content/posts/podcast-155.md
+++ b/hugo/content/posts/podcast-155.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 155"
 date = "2007-12-14T15:18:00"
 categories = ["podcast"]
+filename = "ump_podcast155"
 +++
 
 

--- a/hugo/content/posts/podcast-156.md
+++ b/hugo/content/posts/podcast-156.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 156"
 date = "2007-12-21T17:05:00"
 categories = ["podcast"]
+filename = "ump_podcast156"
 +++
 
 

--- a/hugo/content/posts/podcast-157.md
+++ b/hugo/content/posts/podcast-157.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 157"
 date = "2007-12-28T18:35:00"
 categories = ["podcast"]
+filename = "ump_podcast157"
 +++
 
 

--- a/hugo/content/posts/podcast-158.md
+++ b/hugo/content/posts/podcast-158.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 158"
 date = "2008-01-10T20:17:00"
 categories = ["podcast"]
+filename = "ump_podcast158"
 +++
 
 

--- a/hugo/content/posts/podcast-159.md
+++ b/hugo/content/posts/podcast-159.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 159"
 date = "2008-01-17T19:36:00"
 categories = ["podcast"]
+filename = "ump_podcast159"
 +++
 
 

--- a/hugo/content/posts/podcast-16.md
+++ b/hugo/content/posts/podcast-16.md
@@ -2,6 +2,7 @@
 title = "Выпуск 16"
 date = "2005-09-14T16:11:00"
 categories = ["podcast"]
+filename = "ump_podcast16"
 +++
 
 

--- a/hugo/content/posts/podcast-160.md
+++ b/hugo/content/posts/podcast-160.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 160"
 date = "2008-01-25T21:25:00"
 categories = ["podcast"]
+filename = "ump_podcast160"
 +++
 
 

--- a/hugo/content/posts/podcast-161.md
+++ b/hugo/content/posts/podcast-161.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 161"
 date = "2008-02-01T20:24:00"
 categories = ["podcast"]
+filename = "ump_podcast161"
 +++
 
 

--- a/hugo/content/posts/podcast-162.md
+++ b/hugo/content/posts/podcast-162.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 162"
 date = "2008-02-09T13:46:00"
 categories = ["podcast"]
+filename = "ump_podcast162"
 +++
 
 

--- a/hugo/content/posts/podcast-163.md
+++ b/hugo/content/posts/podcast-163.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 163"
 date = "2008-02-15T17:43:00"
 categories = ["podcast"]
+filename = "ump_podcast163"
 +++
 
 

--- a/hugo/content/posts/podcast-164.md
+++ b/hugo/content/posts/podcast-164.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 164"
 date = "2008-02-24T17:48:00"
 categories = ["podcast"]
+filename = "ump_podcast164"
 +++
 
 

--- a/hugo/content/posts/podcast-165.md
+++ b/hugo/content/posts/podcast-165.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 165"
 date = "2008-02-29T19:34:00"
 categories = ["podcast"]
+filename = "ump_podcast165"
 +++
 
 

--- a/hugo/content/posts/podcast-166.md
+++ b/hugo/content/posts/podcast-166.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 166"
 date = "2008-03-08T20:22:00"
 categories = ["podcast"]
+filename = "ump_podcast166"
 +++
 
 

--- a/hugo/content/posts/podcast-167.md
+++ b/hugo/content/posts/podcast-167.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 167"
 date = "2008-03-15T19:46:00"
 categories = ["podcast"]
+filename = "ump_podcast167"
 +++
 
 

--- a/hugo/content/posts/podcast-168.md
+++ b/hugo/content/posts/podcast-168.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 168"
 date = "2008-03-22T13:41:00"
 categories = ["podcast"]
+filename = "ump_podcast168"
 +++
 
 

--- a/hugo/content/posts/podcast-169.md
+++ b/hugo/content/posts/podcast-169.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 169"
 date = "2008-03-27T15:07:00"
 categories = ["podcast"]
+filename = "ump_podcast169"
 +++
 
 

--- a/hugo/content/posts/podcast-17.md
+++ b/hugo/content/posts/podcast-17.md
@@ -2,6 +2,7 @@
 title = "Выпуск 17"
 date = "2005-09-18T11:32:00"
 categories = ["podcast"]
+filename = "ump_podcast17"
 +++
 
 

--- a/hugo/content/posts/podcast-170.md
+++ b/hugo/content/posts/podcast-170.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 170"
 date = "2008-04-04T22:33:00"
 categories = ["podcast"]
+filename = "ump_podcast170"
 +++
 
 

--- a/hugo/content/posts/podcast-171.md
+++ b/hugo/content/posts/podcast-171.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 171"
 date = "2008-04-11T13:42:00"
 categories = ["podcast"]
+filename = "ump_podcast171"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp171.jpg)

--- a/hugo/content/posts/podcast-172.md
+++ b/hugo/content/posts/podcast-172.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 172"
 date = "2008-04-18T17:14:00"
 categories = ["podcast"]
+filename = "ump_podcast172"
 +++
 
 

--- a/hugo/content/posts/podcast-173.md
+++ b/hugo/content/posts/podcast-173.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 173"
 date = "2008-04-27T15:36:00"
 categories = ["podcast"]
+filename = "ump_podcast173"
 +++
 
 

--- a/hugo/content/posts/podcast-174.md
+++ b/hugo/content/posts/podcast-174.md
@@ -2,6 +2,7 @@
 title = "Музыка из UWP 2"
 date = "2008-04-30T20:05:00"
 categories = ["others"]
+filename = "ump_podcast174"
 +++
 
 

--- a/hugo/content/posts/podcast-175.md
+++ b/hugo/content/posts/podcast-175.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 175"
 date = "2008-05-10T17:52:00"
 categories = ["podcast"]
+filename = "ump_podcast175"
 +++
 
 

--- a/hugo/content/posts/podcast-176.md
+++ b/hugo/content/posts/podcast-176.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 176"
 date = "2008-05-15T16:36:00"
 categories = ["podcast"]
+filename = "ump_podcast176"
 +++
 
 

--- a/hugo/content/posts/podcast-177.md
+++ b/hugo/content/posts/podcast-177.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 177"
 date = "2008-05-24T20:11:00"
 categories = ["podcast"]
+filename = "ump_podcast177"
 +++
 
 

--- a/hugo/content/posts/podcast-178.md
+++ b/hugo/content/posts/podcast-178.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 178"
 date = "2008-06-01T13:59:00"
 categories = ["podcast"]
+filename = "ump_podcast178"
 +++
 
 

--- a/hugo/content/posts/podcast-179.md
+++ b/hugo/content/posts/podcast-179.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 179"
 date = "2008-06-08T19:27:00"
 categories = ["podcast"]
+filename = "ump_podcast179"
 +++
 
 

--- a/hugo/content/posts/podcast-18.md
+++ b/hugo/content/posts/podcast-18.md
@@ -2,6 +2,7 @@
 title = "Выпуск 18"
 date = "2005-09-22T18:17:00"
 categories = ["podcast"]
+filename = "ump_podcast18"
 +++
 
 

--- a/hugo/content/posts/podcast-180.md
+++ b/hugo/content/posts/podcast-180.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 180"
 date = "2008-06-15T13:07:00"
 categories = ["podcast"]
+filename = "ump_podcast180"
 +++
 
 

--- a/hugo/content/posts/podcast-181.md
+++ b/hugo/content/posts/podcast-181.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 181"
 date = "2008-06-22T17:45:00"
 categories = ["podcast"]
+filename = "ump_podcast181"
 +++
 
 

--- a/hugo/content/posts/podcast-182.md
+++ b/hugo/content/posts/podcast-182.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 182"
 date = "2008-06-29T20:46:00"
 categories = ["podcast"]
+filename = "ump_podcast182"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp182.jpg)

--- a/hugo/content/posts/podcast-183.md
+++ b/hugo/content/posts/podcast-183.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 183"
 date = "2008-07-07T20:47:00"
 categories = ["podcast"]
+filename = "ump_podcast183"
 +++
 
 3 года в эфире!

--- a/hugo/content/posts/podcast-184.md
+++ b/hugo/content/posts/podcast-184.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 184"
 date = "2008-07-14T15:55:00"
 categories = ["podcast"]
+filename = "ump_podcast184"
 +++
 
 

--- a/hugo/content/posts/podcast-185.md
+++ b/hugo/content/posts/podcast-185.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 185"
 date = "2008-07-22T18:31:00"
 categories = ["podcast"]
+filename = "ump_podcast185"
 +++
 
 

--- a/hugo/content/posts/podcast-186.md
+++ b/hugo/content/posts/podcast-186.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 186"
 date = "2008-07-31T19:33:00"
 categories = ["podcast"]
+filename = "ump_podcast186"
 +++
 
 

--- a/hugo/content/posts/podcast-187.md
+++ b/hugo/content/posts/podcast-187.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 187"
 date = "2008-08-06T16:58:00"
 categories = ["podcast"]
+filename = "ump_podcast187"
 +++
 
 

--- a/hugo/content/posts/podcast-188.md
+++ b/hugo/content/posts/podcast-188.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 188"
 date = "2008-08-21T15:54:00"
 categories = ["podcast"]
+filename = "ump_podcast188"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp188.jpg)

--- a/hugo/content/posts/podcast-189.md
+++ b/hugo/content/posts/podcast-189.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 189"
 date = "2008-08-28T12:28:00"
 categories = ["podcast"]
+filename = "ump_podcast189"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp189.png)

--- a/hugo/content/posts/podcast-19.md
+++ b/hugo/content/posts/podcast-19.md
@@ -2,6 +2,7 @@
 title = "Выпуск 19"
 date = "2005-09-26T17:34:00"
 categories = ["podcast"]
+filename = "ump_podcast19"
 +++
 
 

--- a/hugo/content/posts/podcast-190.md
+++ b/hugo/content/posts/podcast-190.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 190"
 date = "2008-09-04T17:37:00"
 categories = ["podcast"]
+filename = "ump_podcast190"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp190.png)

--- a/hugo/content/posts/podcast-191.md
+++ b/hugo/content/posts/podcast-191.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 191"
 date = "2008-09-14T13:48:00"
 categories = ["podcast"]
+filename = "ump_podcast191"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp191.png)

--- a/hugo/content/posts/podcast-192.md
+++ b/hugo/content/posts/podcast-192.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 192"
 date = "2008-09-19T15:01:00"
 categories = ["podcast"]
+filename = "ump_podcast192"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp192.jpg)

--- a/hugo/content/posts/podcast-193.md
+++ b/hugo/content/posts/podcast-193.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 193"
 date = "2008-09-26T11:33:00"
 categories = ["podcast"]
+filename = "ump_podcast193"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp193.png)

--- a/hugo/content/posts/podcast-194.md
+++ b/hugo/content/posts/podcast-194.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 194"
 date = "2008-10-02T16:28:00"
 categories = ["podcast"]
+filename = "ump_podcast194"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp194.png)

--- a/hugo/content/posts/podcast-195.md
+++ b/hugo/content/posts/podcast-195.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 195"
 date = "2008-10-12T15:01:00"
 categories = ["podcast"]
+filename = "ump_podcast195"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp195.png)

--- a/hugo/content/posts/podcast-196.md
+++ b/hugo/content/posts/podcast-196.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 196"
 date = "2008-10-17T16:55:00"
 categories = ["podcast"]
+filename = "ump_podcast196"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp196.jpg)

--- a/hugo/content/posts/podcast-197.md
+++ b/hugo/content/posts/podcast-197.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 197"
 date = "2008-10-28T19:27:00"
 categories = ["podcast"]
+filename = "ump_podcast197"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp197.png)

--- a/hugo/content/posts/podcast-198.md
+++ b/hugo/content/posts/podcast-198.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 198"
 date = "2008-11-06T17:52:00"
 categories = ["podcast"]
+filename = "ump_podcast198"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp198.jpg)

--- a/hugo/content/posts/podcast-199.md
+++ b/hugo/content/posts/podcast-199.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 199"
 date = "2008-11-14T15:53:00"
 categories = ["podcast"]
+filename = "ump_podcast199"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp199.jpg)

--- a/hugo/content/posts/podcast-2.md
+++ b/hugo/content/posts/podcast-2.md
@@ -2,6 +2,7 @@
 title = "Выпуск 2"
 date = "2005-07-31T11:08:00"
 categories = ["podcast"]
+filename = "ump_podcast2"
 +++
 
 

--- a/hugo/content/posts/podcast-20.md
+++ b/hugo/content/posts/podcast-20.md
@@ -2,6 +2,7 @@
 title = "Выпуск 20"
 date = "2005-09-29T16:26:00"
 categories = ["podcast"]
+filename = "ump_podcast20"
 +++
 
 

--- a/hugo/content/posts/podcast-200.md
+++ b/hugo/content/posts/podcast-200.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 200"
 date = "2008-11-22T07:01:00"
 categories = ["podcast"]
+filename = "ump_podcast200"
 +++
 
 

--- a/hugo/content/posts/podcast-201.md
+++ b/hugo/content/posts/podcast-201.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 201"
 date = "2008-11-28T15:07:00"
 categories = ["podcast"]
+filename = "ump_podcast201"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp201.jpg)

--- a/hugo/content/posts/podcast-202.md
+++ b/hugo/content/posts/podcast-202.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 202"
 date = "2008-12-05T18:33:00"
 categories = ["podcast"]
+filename = "ump_podcast202"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp202.jpg)

--- a/hugo/content/posts/podcast-203.md
+++ b/hugo/content/posts/podcast-203.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 203"
 date = "2008-12-14T17:42:00"
 categories = ["podcast"]
+filename = "ump_podcast203"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp203.png)

--- a/hugo/content/posts/podcast-204.md
+++ b/hugo/content/posts/podcast-204.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 204"
 date = "2008-12-26T17:07:00"
 categories = ["podcast"]
+filename = "ump_podcast204"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp204.jpg)

--- a/hugo/content/posts/podcast-205.md
+++ b/hugo/content/posts/podcast-205.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 205"
 date = "2009-01-04T17:04:00"
 categories = ["podcast"]
+filename = "ump_podcast205"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp205.jpg)

--- a/hugo/content/posts/podcast-206.md
+++ b/hugo/content/posts/podcast-206.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 206"
 date = "2009-01-09T21:09:00"
 categories = ["podcast"]
+filename = "ump_podcast206"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp206.jpg)

--- a/hugo/content/posts/podcast-207.md
+++ b/hugo/content/posts/podcast-207.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 207"
 date = "2009-01-21T15:49:00"
 categories = ["podcast"]
+filename = "ump_podcast207"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp207.jpg)

--- a/hugo/content/posts/podcast-208.md
+++ b/hugo/content/posts/podcast-208.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 208"
 date = "2009-01-29T18:58:00"
 categories = ["podcast"]
+filename = "ump_podcast208"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp208.jpg)

--- a/hugo/content/posts/podcast-209.md
+++ b/hugo/content/posts/podcast-209.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 209"
 date = "2009-02-08T17:09:00"
 categories = ["podcast"]
+filename = "ump_podcast209"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp209.jpg)

--- a/hugo/content/posts/podcast-21.md
+++ b/hugo/content/posts/podcast-21.md
@@ -2,6 +2,7 @@
 title = "Выпуск 21"
 date = "2005-10-03T17:25:00"
 categories = ["podcast"]
+filename = "ump_podcast21"
 +++
 
 

--- a/hugo/content/posts/podcast-210.md
+++ b/hugo/content/posts/podcast-210.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 210"
 date = "2009-02-16T14:43:00"
 categories = ["podcast"]
+filename = "ump_podcast210"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp210.jpg)

--- a/hugo/content/posts/podcast-211.md
+++ b/hugo/content/posts/podcast-211.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 211"
 date = "2009-02-24T18:50:00"
 categories = ["podcast"]
+filename = "ump_podcast211"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp211.jpg)

--- a/hugo/content/posts/podcast-212.md
+++ b/hugo/content/posts/podcast-212.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 212"
 date = "2009-03-06T12:03:00"
 categories = ["podcast"]
+filename = "ump_podcast212"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp212.jpg)

--- a/hugo/content/posts/podcast-213.md
+++ b/hugo/content/posts/podcast-213.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 213"
 date = "2009-03-13T16:20:00"
 categories = ["podcast"]
+filename = "ump_podcast213"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp213.jpg)

--- a/hugo/content/posts/podcast-214.md
+++ b/hugo/content/posts/podcast-214.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 214"
 date = "2009-03-21T08:21:00"
 categories = ["podcast"]
+filename = "ump_podcast214"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp214.jpg)

--- a/hugo/content/posts/podcast-215.md
+++ b/hugo/content/posts/podcast-215.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 215"
 date = "2009-04-05T15:36:00"
 categories = ["podcast"]
+filename = "ump_podcast215"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp215.jpg)

--- a/hugo/content/posts/podcast-216.md
+++ b/hugo/content/posts/podcast-216.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 216"
 date = "2009-04-12T12:56:00"
 categories = ["podcast"]
+filename = "ump_podcast216"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp216.jpg)

--- a/hugo/content/posts/podcast-217.md
+++ b/hugo/content/posts/podcast-217.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 217"
 date = "2009-04-19T16:30:00"
 categories = ["podcast"]
+filename = "ump_podcast217"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp217.jpg)

--- a/hugo/content/posts/podcast-218.md
+++ b/hugo/content/posts/podcast-218.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 218"
 date = "2009-05-04T16:40:00"
 categories = ["podcast"]
+filename = "ump_podcast218"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp218.jpg)

--- a/hugo/content/posts/podcast-219.md
+++ b/hugo/content/posts/podcast-219.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 219"
 date = "2009-05-10T13:30:00"
 categories = ["podcast"]
+filename = "ump_podcast219"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp219.jpg)

--- a/hugo/content/posts/podcast-22.md
+++ b/hugo/content/posts/podcast-22.md
@@ -2,6 +2,7 @@
 title = "Выпуск 22"
 date = "2005-10-06T20:32:00"
 categories = ["podcast"]
+filename = "ump_podcast22"
 +++
 
 

--- a/hugo/content/posts/podcast-220.md
+++ b/hugo/content/posts/podcast-220.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 220"
 date = "2009-05-25T16:21:00"
 categories = ["podcast"]
+filename = "ump_podcast220"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp220.jpg)

--- a/hugo/content/posts/podcast-221.md
+++ b/hugo/content/posts/podcast-221.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 221"
 date = "2009-06-07T19:30:00"
 categories = ["podcast"]
+filename = "ump_podcast221"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp221.jpg)

--- a/hugo/content/posts/podcast-222.md
+++ b/hugo/content/posts/podcast-222.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 222"
 date = "2009-06-17T21:44:00"
 categories = ["podcast"]
+filename = "ump_podcast222"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp222.jpg)

--- a/hugo/content/posts/podcast-223.md
+++ b/hugo/content/posts/podcast-223.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 223"
 date = "2009-06-24T19:31:00"
 categories = ["podcast"]
+filename = "ump_podcast223"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp223.jpg)

--- a/hugo/content/posts/podcast-224.md
+++ b/hugo/content/posts/podcast-224.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 224"
 date = "2009-07-09T18:21:00"
 categories = ["podcast"]
+filename = "ump_podcast224"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp224.jpg)

--- a/hugo/content/posts/podcast-225.md
+++ b/hugo/content/posts/podcast-225.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 225"
 date = "2009-07-19T18:00:00"
 categories = ["podcast"]
+filename = "ump_podcast225"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp225.jpg)

--- a/hugo/content/posts/podcast-226.md
+++ b/hugo/content/posts/podcast-226.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 226"
 date = "2009-07-30T21:19:00"
 categories = ["podcast"]
+filename = "ump_podcast226"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp226.jpg)

--- a/hugo/content/posts/podcast-227.md
+++ b/hugo/content/posts/podcast-227.md
@@ -2,6 +2,7 @@
 title = "UWP – Выпуск 227"
 date = "2009-08-12T21:19:00"
 categories = ["podcast"]
+filename = "ump_podcast227"
 +++
 
 - Два уровня секретности для поступления в школу

--- a/hugo/content/posts/podcast-228.md
+++ b/hugo/content/posts/podcast-228.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 228"
 date = "2009-08-26T16:20:00"
 categories = ["podcast"]
+filename = "ump_podcast228"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp228.jpg)

--- a/hugo/content/posts/podcast-229.md
+++ b/hugo/content/posts/podcast-229.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 229"
 date = "2009-09-13T16:51:00"
 categories = ["podcast"]
+filename = "ump_podcast229"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp229.jpg)

--- a/hugo/content/posts/podcast-23.md
+++ b/hugo/content/posts/podcast-23.md
@@ -2,6 +2,7 @@
 title = "Выпуск 23"
 date = "2005-10-09T20:33:00"
 categories = ["podcast"]
+filename = "ump_podcast23"
 +++
 
 

--- a/hugo/content/posts/podcast-230.md
+++ b/hugo/content/posts/podcast-230.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 230"
 date = "2009-09-24T16:26:00"
 categories = ["podcast"]
+filename = "ump_podcast230"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp230.jpg)

--- a/hugo/content/posts/podcast-231.md
+++ b/hugo/content/posts/podcast-231.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 231"
 date = "2009-10-11T15:05:00"
 categories = ["podcast"]
+filename = "ump_podcast231"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp231.jpg)

--- a/hugo/content/posts/podcast-232.md
+++ b/hugo/content/posts/podcast-232.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 232"
 date = "2009-10-21T14:41:00"
 categories = ["podcast"]
+filename = "ump_podcast232"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp232.jpg)

--- a/hugo/content/posts/podcast-233.md
+++ b/hugo/content/posts/podcast-233.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 233"
 date = "2009-10-29T15:50:00"
 categories = ["podcast"]
+filename = "ump_podcast233"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp233.jpg)

--- a/hugo/content/posts/podcast-234.md
+++ b/hugo/content/posts/podcast-234.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 234"
 date = "2009-11-18T11:30:00"
 categories = ["podcast"]
+filename = "ump_podcast234"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp234.jpg)

--- a/hugo/content/posts/podcast-235.md
+++ b/hugo/content/posts/podcast-235.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 235"
 date = "2009-11-26T13:19:00"
 categories = ["podcast"]
+filename = "ump_podcast235"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp235.jpg)

--- a/hugo/content/posts/podcast-236.md
+++ b/hugo/content/posts/podcast-236.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 236"
 date = "2009-12-07T16:59:00"
 categories = ["podcast"]
+filename = "ump_podcast236"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp236.jpg)

--- a/hugo/content/posts/podcast-237.md
+++ b/hugo/content/posts/podcast-237.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 237"
 date = "2009-12-23T17:37:00"
 categories = ["podcast"]
+filename = "ump_podcast237"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp237.png)

--- a/hugo/content/posts/podcast-238.md
+++ b/hugo/content/posts/podcast-238.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 238"
 date = "2010-01-10T15:55:00"
 categories = ["podcast"]
+filename = "ump_podcast238"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp238.jpg)

--- a/hugo/content/posts/podcast-239.md
+++ b/hugo/content/posts/podcast-239.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 239"
 date = "2010-01-29T10:52:00"
 categories = ["podcast"]
+filename = "ump_podcast239"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp239.jpg)

--- a/hugo/content/posts/podcast-24.md
+++ b/hugo/content/posts/podcast-24.md
@@ -2,6 +2,7 @@
 title = "Выпуск 24"
 date = "2005-10-13T21:38:00"
 categories = ["podcast"]
+filename = "ump_podcast24"
 +++
 
 

--- a/hugo/content/posts/podcast-240.md
+++ b/hugo/content/posts/podcast-240.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 240"
 date = "2010-02-08T23:15:00"
 categories = ["podcast"]
+filename = "ump_podcast240"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp240.jpg)

--- a/hugo/content/posts/podcast-241.md
+++ b/hugo/content/posts/podcast-241.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 241"
 date = "2010-02-24T15:39:00"
 categories = ["podcast"]
+filename = "ump_podcast241"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp241.jpg)

--- a/hugo/content/posts/podcast-242.md
+++ b/hugo/content/posts/podcast-242.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 242"
 date = "2010-03-18T16:17:00"
 categories = ["podcast"]
+filename = "ump_podcast242"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp242.jpg)

--- a/hugo/content/posts/podcast-243.md
+++ b/hugo/content/posts/podcast-243.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 243"
 date = "2010-04-05T13:15:00"
 categories = ["podcast"]
+filename = "ump_podcast243"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp243.jpg)

--- a/hugo/content/posts/podcast-244.md
+++ b/hugo/content/posts/podcast-244.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 244"
 date = "2010-04-12T12:32:00"
 categories = ["podcast"]
+filename = "ump_podcast244"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp244.jpg)

--- a/hugo/content/posts/podcast-245.md
+++ b/hugo/content/posts/podcast-245.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 245"
 date = "2010-04-19T12:14:00"
 categories = ["podcast"]
+filename = "ump_podcast245"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp245.jpg)

--- a/hugo/content/posts/podcast-246.md
+++ b/hugo/content/posts/podcast-246.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 246"
 date = "2010-04-26T11:46:00"
 categories = ["podcast"]
+filename = "ump_podcast246"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp246.jpg)

--- a/hugo/content/posts/podcast-247.md
+++ b/hugo/content/posts/podcast-247.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 247"
 date = "2010-05-03T12:26:00"
 categories = ["podcast"]
+filename = "ump_podcast247"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp247.jpg)

--- a/hugo/content/posts/podcast-248.md
+++ b/hugo/content/posts/podcast-248.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 248"
 date = "2010-05-19T13:38:00"
 categories = ["podcast"]
+filename = "ump_podcast248"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp248.jpg)

--- a/hugo/content/posts/podcast-249.md
+++ b/hugo/content/posts/podcast-249.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 249"
 date = "2010-05-24T12:48:00"
 categories = ["podcast"]
+filename = "ump_podcast249"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp249.jpg)

--- a/hugo/content/posts/podcast-25.md
+++ b/hugo/content/posts/podcast-25.md
@@ -2,6 +2,7 @@
 title = "Выпуск 25"
 date = "2005-10-17T15:28:00"
 categories = ["podcast"]
+filename = "ump_podcast25"
 +++
 
 

--- a/hugo/content/posts/podcast-250.md
+++ b/hugo/content/posts/podcast-250.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 250"
 date = "2010-06-10T19:30:00"
 categories = ["podcast"]
+filename = "ump_podcast250"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp250.jpg)

--- a/hugo/content/posts/podcast-251.md
+++ b/hugo/content/posts/podcast-251.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 251"
 date = "2010-06-14T14:07:00"
 categories = ["podcast"]
+filename = "ump_podcast251"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp251.png)

--- a/hugo/content/posts/podcast-252.md
+++ b/hugo/content/posts/podcast-252.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 252"
 date = "2010-06-24T12:36:00"
 categories = ["podcast"]
+filename = "ump_podcast252"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp252.jpg)

--- a/hugo/content/posts/podcast-253.md
+++ b/hugo/content/posts/podcast-253.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 253"
 date = "2010-07-01T16:33:00"
 categories = ["podcast"]
+filename = "ump_podcast253"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp253.jpg)

--- a/hugo/content/posts/podcast-254.md
+++ b/hugo/content/posts/podcast-254.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 254"
 date = "2010-07-22T20:52:00"
 categories = ["podcast"]
+filename = "ump_podcast254"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp254.png)

--- a/hugo/content/posts/podcast-255.md
+++ b/hugo/content/posts/podcast-255.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 255"
 date = "2010-07-29T07:51:00"
 categories = ["podcast"]
+filename = "ump_podcast255"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp255.jpg)

--- a/hugo/content/posts/podcast-256.md
+++ b/hugo/content/posts/podcast-256.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 256"
 date = "2010-08-22T17:57:00"
 categories = ["podcast"]
+filename = "ump_podcast256"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp256.jpg)

--- a/hugo/content/posts/podcast-257.md
+++ b/hugo/content/posts/podcast-257.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 257"
 date = "2010-09-10T13:19:00"
 categories = ["podcast"]
+filename = "ump_podcast257"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp257.gif)

--- a/hugo/content/posts/podcast-258.md
+++ b/hugo/content/posts/podcast-258.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 258"
 date = "2010-09-17T16:50:00"
 categories = ["podcast"]
+filename = "ump_podcast258"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp258.jpg)

--- a/hugo/content/posts/podcast-259.md
+++ b/hugo/content/posts/podcast-259.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 259"
 date = "2010-10-06T20:13:00"
 categories = ["podcast"]
+filename = "ump_podcast259"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp259.jpg)

--- a/hugo/content/posts/podcast-26.md
+++ b/hugo/content/posts/podcast-26.md
@@ -2,6 +2,7 @@
 title = "Выпуск 26"
 date = "2005-10-21T16:35:00"
 categories = ["podcast"]
+filename = "ump_podcast26"
 +++
 
 

--- a/hugo/content/posts/podcast-260.md
+++ b/hugo/content/posts/podcast-260.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 260"
 date = "2010-10-22T10:43:00"
 categories = ["podcast"]
+filename = "ump_podcast260"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp260.jpg)

--- a/hugo/content/posts/podcast-261.md
+++ b/hugo/content/posts/podcast-261.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 261"
 date = "2010-11-08T13:35:00"
 categories = ["podcast"]
+filename = "ump_podcast261"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp261.jpg)

--- a/hugo/content/posts/podcast-262.md
+++ b/hugo/content/posts/podcast-262.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 262"
 date = "2010-12-09T19:26:00"
 categories = ["podcast"]
+filename = "ump_podcast262"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp262.jpg)

--- a/hugo/content/posts/podcast-263.md
+++ b/hugo/content/posts/podcast-263.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 263"
 date = "2010-12-19T13:21:00"
 categories = ["podcast"]
+filename = "ump_podcast263"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp263.jpg)

--- a/hugo/content/posts/podcast-264.md
+++ b/hugo/content/posts/podcast-264.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 264"
 date = "2011-01-14T18:35:00"
 categories = ["podcast"]
+filename = "ump_podcast264"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp264.jpg)

--- a/hugo/content/posts/podcast-265.md
+++ b/hugo/content/posts/podcast-265.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 265"
 date = "2011-02-11T14:06:00"
 categories = ["podcast"]
+filename = "ump_podcast265"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp265.jpg)

--- a/hugo/content/posts/podcast-266.md
+++ b/hugo/content/posts/podcast-266.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 266"
 date = "2011-03-04T13:21:00"
 categories = ["podcast"]
+filename = "ump_podcast266"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp266.png)

--- a/hugo/content/posts/podcast-267.md
+++ b/hugo/content/posts/podcast-267.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 267"
 date = "2011-03-11T17:54:00"
 categories = ["podcast"]
+filename = "ump_podcast267"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp267.jpg)

--- a/hugo/content/posts/podcast-268.md
+++ b/hugo/content/posts/podcast-268.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 268"
 date = "2011-03-28T17:46:00"
 categories = ["podcast"]
+filename = "ump_podcast268"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp268.jpg)

--- a/hugo/content/posts/podcast-269.md
+++ b/hugo/content/posts/podcast-269.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 269"
 date = "2011-04-06T19:41:00"
 categories = ["podcast"]
+filename = "ump_podcast269"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp269.jpg)

--- a/hugo/content/posts/podcast-27.md
+++ b/hugo/content/posts/podcast-27.md
@@ -2,6 +2,7 @@
 title = "Выпуск 27"
 date = "2005-10-25T11:29:00"
 categories = ["podcast"]
+filename = "ump_podcast27"
 +++
 
 

--- a/hugo/content/posts/podcast-270.md
+++ b/hugo/content/posts/podcast-270.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 270"
 date = "2011-05-03T20:16:00"
 categories = ["podcast"]
+filename = "ump_podcast270"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp270.jpg)

--- a/hugo/content/posts/podcast-271.md
+++ b/hugo/content/posts/podcast-271.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 271"
 date = "2011-06-01T21:25:00"
 categories = ["podcast"]
+filename = "ump_podcast271"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp271.jpg)

--- a/hugo/content/posts/podcast-272.md
+++ b/hugo/content/posts/podcast-272.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 272"
 date = "2011-06-17T19:14:00"
 categories = ["podcast"]
+filename = "ump_podcast272"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp272.png)

--- a/hugo/content/posts/podcast-273.md
+++ b/hugo/content/posts/podcast-273.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 273"
 date = "2011-07-01T18:54:00"
 categories = ["podcast"]
+filename = "ump_podcast273"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp273.jpg)

--- a/hugo/content/posts/podcast-274.md
+++ b/hugo/content/posts/podcast-274.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 274"
 date = "2011-07-29T21:44:00"
 categories = ["podcast"]
+filename = "ump_podcast274"
 +++
 
 

--- a/hugo/content/posts/podcast-275.md
+++ b/hugo/content/posts/podcast-275.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 275"
 date = "2011-08-24T20:48:00"
 categories = ["podcast"]
+filename = "ump_podcast275"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp275.JPG)

--- a/hugo/content/posts/podcast-276.md
+++ b/hugo/content/posts/podcast-276.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 276"
 date = "2011-09-01T16:36:00"
 categories = ["podcast"]
+filename = "ump_podcast276"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp276.jpg)

--- a/hugo/content/posts/podcast-277.md
+++ b/hugo/content/posts/podcast-277.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 277"
 date = "2011-09-09T20:12:00"
 categories = ["podcast"]
+filename = "ump_podcast277"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp277.jpeg)

--- a/hugo/content/posts/podcast-278.md
+++ b/hugo/content/posts/podcast-278.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 278"
 date = "2011-09-21T20:18:00"
 categories = ["podcast"]
+filename = "ump_podcast278"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp278.jpg)

--- a/hugo/content/posts/podcast-279.md
+++ b/hugo/content/posts/podcast-279.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 279"
 date = "2011-10-13T17:41:00"
 categories = ["podcast"]
+filename = "ump_podcast279"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp279.jpg)

--- a/hugo/content/posts/podcast-28.md
+++ b/hugo/content/posts/podcast-28.md
@@ -2,6 +2,7 @@
 title = "Выпуск 28"
 date = "2005-10-29T18:53:00"
 categories = ["podcast"]
+filename = "ump_podcast28"
 +++
 
 

--- a/hugo/content/posts/podcast-280.md
+++ b/hugo/content/posts/podcast-280.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 280"
 date = "2011-10-28T21:11:00"
 categories = ["podcast"]
+filename = "ump_podcast280"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp280.jpeg)

--- a/hugo/content/posts/podcast-281.md
+++ b/hugo/content/posts/podcast-281.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 281"
 date = "2011-11-11T20:51:00"
 categories = ["podcast"]
+filename = "ump_podcast281"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp281.jpg)

--- a/hugo/content/posts/podcast-282.md
+++ b/hugo/content/posts/podcast-282.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 282"
 date = "2011-12-02T18:14:00"
 categories = ["podcast"]
+filename = "ump_podcast282"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp282.jpg)

--- a/hugo/content/posts/podcast-283.md
+++ b/hugo/content/posts/podcast-283.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 283"
 date = "2012-01-06T18:41:00"
 categories = ["podcast"]
+filename = "ump_podcast283"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp283.jpg)

--- a/hugo/content/posts/podcast-284.md
+++ b/hugo/content/posts/podcast-284.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 284"
 date = "2012-02-27T17:46:00"
 categories = ["podcast"]
+filename = "ump_podcast284"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp284.jpg)

--- a/hugo/content/posts/podcast-285.md
+++ b/hugo/content/posts/podcast-285.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 285"
 date = "2012-03-18T15:43:00"
 categories = ["podcast"]
+filename = "ump_podcast285"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp285.jpg)

--- a/hugo/content/posts/podcast-286.md
+++ b/hugo/content/posts/podcast-286.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 286"
 date = "2012-03-25T17:40:00"
 categories = ["podcast"]
+filename = "ump_podcast286"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp286.jpg)

--- a/hugo/content/posts/podcast-287.md
+++ b/hugo/content/posts/podcast-287.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 287"
 date = "2012-04-01T16:16:00"
 categories = ["podcast"]
+filename = "ump_podcast287"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp287.jpg)

--- a/hugo/content/posts/podcast-288.md
+++ b/hugo/content/posts/podcast-288.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 288"
 date = "2012-05-07T20:49:00"
 categories = ["podcast"]
+filename = "ump_podcast288"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp288.jpeg)

--- a/hugo/content/posts/podcast-289.md
+++ b/hugo/content/posts/podcast-289.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 289"
 date = "2012-05-17T17:19:00"
 categories = ["podcast"]
+filename = "ump_podcast289"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp289.jpg)

--- a/hugo/content/posts/podcast-29.md
+++ b/hugo/content/posts/podcast-29.md
@@ -2,6 +2,7 @@
 title = "Выпуск 29"
 date = "2005-11-02T13:29:00"
 categories = ["podcast"]
+filename = "ump_podcast29"
 +++
 
 

--- a/hugo/content/posts/podcast-290.md
+++ b/hugo/content/posts/podcast-290.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 290"
 date = "2012-05-24T16:12:00"
 categories = ["podcast"]
+filename = "ump_podcast290"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp290.jpg)

--- a/hugo/content/posts/podcast-291.md
+++ b/hugo/content/posts/podcast-291.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 291"
 date = "2012-05-31T17:10:00"
 categories = ["podcast"]
+filename = "ump_podcast291"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp291.JPG)

--- a/hugo/content/posts/podcast-292.md
+++ b/hugo/content/posts/podcast-292.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 292"
 date = "2012-06-11T17:01:00"
 categories = ["podcast"]
+filename = "ump_podcast292"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp292.jpg)

--- a/hugo/content/posts/podcast-293.md
+++ b/hugo/content/posts/podcast-293.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 293"
 date = "2012-07-20T19:13:00"
 categories = ["podcast"]
+filename = "ump_podcast293"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp293.jpg)

--- a/hugo/content/posts/podcast-3.md
+++ b/hugo/content/posts/podcast-3.md
@@ -2,6 +2,7 @@
 title = "Выпуск 3"
 date = "2005-08-04T16:08:00"
 categories = ["podcast"]
+filename = "ump_podcast3"
 +++
 
 

--- a/hugo/content/posts/podcast-30.md
+++ b/hugo/content/posts/podcast-30.md
@@ -2,6 +2,7 @@
 title = "Выпуск 30"
 date = "2005-11-06T14:32:00"
 categories = ["podcast"]
+filename = "ump_podcast30"
 +++
 
 

--- a/hugo/content/posts/podcast-31.md
+++ b/hugo/content/posts/podcast-31.md
@@ -2,6 +2,7 @@
 title = "Выпуск 31"
 date = "2005-11-09T18:23:00"
 categories = ["podcast"]
+filename = "ump_podcast31"
 +++
 
 

--- a/hugo/content/posts/podcast-315.md
+++ b/hugo/content/posts/podcast-315.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 315"
 date = "2013-04-14T14:56:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp315.jpg"
+filename = "ump_podcast315"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp315.jpg)

--- a/hugo/content/posts/podcast-316.md
+++ b/hugo/content/posts/podcast-316.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 316"
 date = "2013-05-03T19:11:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp316.jpg"
+filename = "ump_podcast316"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp316.jpg)

--- a/hugo/content/posts/podcast-317.md
+++ b/hugo/content/posts/podcast-317.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 317"
 date = "2013-05-24T18:04:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp317.jpg"
+filename = "ump_podcast317"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp317.jpg)

--- a/hugo/content/posts/podcast-318.md
+++ b/hugo/content/posts/podcast-318.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 318"
 date = "2013-06-07T19:57:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp318.jpg"
+filename = "ump_podcast318"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp318.jpg)

--- a/hugo/content/posts/podcast-319.md
+++ b/hugo/content/posts/podcast-319.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 319"
 date = "2013-06-28T20:27:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp319.jpg"
+filename = "ump_podcast319"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp319.jpg)

--- a/hugo/content/posts/podcast-32.md
+++ b/hugo/content/posts/podcast-32.md
@@ -2,6 +2,7 @@
 title = "Выпуск 32"
 date = "2005-11-13T15:40:00"
 categories = ["podcast"]
+filename = "ump_podcast32"
 +++
 
 

--- a/hugo/content/posts/podcast-320.md
+++ b/hugo/content/posts/podcast-320.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 320"
 date = "2013-07-26T17:33:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp320.jpg"
+filename = "ump_podcast320"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp320.jpg)

--- a/hugo/content/posts/podcast-321.md
+++ b/hugo/content/posts/podcast-321.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 321"
 date = "2013-08-09T18:52:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp321.png"
+filename = "ump_podcast321"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp321.png)

--- a/hugo/content/posts/podcast-322.md
+++ b/hugo/content/posts/podcast-322.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 322"
 date = "2013-08-18T15:26:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp322.jpg"
+filename = "ump_podcast322"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp322.jpg)

--- a/hugo/content/posts/podcast-323.md
+++ b/hugo/content/posts/podcast-323.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 323"
 date = "2013-09-01T19:08:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp323.jpg"
+filename = "ump_podcast323"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp323.jpg)

--- a/hugo/content/posts/podcast-324.md
+++ b/hugo/content/posts/podcast-324.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 324"
 date = "2013-09-20T15:10:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp324.jpg"
+filename = "ump_podcast324"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp324.jpg)

--- a/hugo/content/posts/podcast-325.md
+++ b/hugo/content/posts/podcast-325.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 325"
 date = "2013-09-30T17:13:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp325.jpg"
+filename = "ump_podcast325"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp325.jpg)

--- a/hugo/content/posts/podcast-326.md
+++ b/hugo/content/posts/podcast-326.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 326"
 date = "2013-10-13T15:21:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp326.jpg"
+filename = "ump_podcast326"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp326.jpg)

--- a/hugo/content/posts/podcast-327.md
+++ b/hugo/content/posts/podcast-327.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 327"
 date = "2013-11-04T14:51:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp327.jpg"
+filename = "ump_podcast327"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp327.jpg)

--- a/hugo/content/posts/podcast-328.md
+++ b/hugo/content/posts/podcast-328.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 328"
 date = "2013-11-22T16:07:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp328.jpg"
+filename = "ump_podcast328"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp328.jpg)

--- a/hugo/content/posts/podcast-329.md
+++ b/hugo/content/posts/podcast-329.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 329"
 date = "2013-11-29T16:45:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp329.jpg"
+filename = "ump_podcast329"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp329.jpg)

--- a/hugo/content/posts/podcast-33.md
+++ b/hugo/content/posts/podcast-33.md
@@ -2,6 +2,7 @@
 title = "Выпуск 33"
 date = "2005-11-16T18:58:00"
 categories = ["podcast"]
+filename = "ump_podcast33"
 +++
 
 

--- a/hugo/content/posts/podcast-330.md
+++ b/hugo/content/posts/podcast-330.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 330"
 date = "2013-12-22T17:18:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp330.jpg"
+filename = "ump_podcast330"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp330.jpg)

--- a/hugo/content/posts/podcast-331.md
+++ b/hugo/content/posts/podcast-331.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 331"
 date = "2014-01-28T18:28:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp331.jpg"
+filename = "ump_podcast331"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp331.jpg)

--- a/hugo/content/posts/podcast-332.md
+++ b/hugo/content/posts/podcast-332.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 332"
 date = "2014-02-27T20:27:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp332.jpg"
+filename = "ump_podcast332"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp332.jpg)

--- a/hugo/content/posts/podcast-333.md
+++ b/hugo/content/posts/podcast-333.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 333"
 date = "2014-03-09T17:21:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp333.jpg"
+filename = "ump_podcast333"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp333.jpg)

--- a/hugo/content/posts/podcast-334.md
+++ b/hugo/content/posts/podcast-334.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 334"
 date = "2014-03-23T16:36:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp334.jpg"
+filename = "ump_podcast334"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp334.jpg)

--- a/hugo/content/posts/podcast-335.md
+++ b/hugo/content/posts/podcast-335.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 335"
 date = "2014-04-27T15:46:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp335.jpg"
+filename = "ump_podcast335"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp335.jpg)

--- a/hugo/content/posts/podcast-336.md
+++ b/hugo/content/posts/podcast-336.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 336"
 date = "2014-05-11T15:37:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp336.jpg"
+filename = "ump_podcast336"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp336.jpg)

--- a/hugo/content/posts/podcast-337.md
+++ b/hugo/content/posts/podcast-337.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 337"
 date = "2014-06-01T16:10:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp337.jpg"
+filename = "ump_podcast337"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp337.jpg)

--- a/hugo/content/posts/podcast-338.md
+++ b/hugo/content/posts/podcast-338.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 338"
 date = "2014-06-20T15:52:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp338.jpg"
+filename = "ump_podcast338"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp338.jpg)

--- a/hugo/content/posts/podcast-339.md
+++ b/hugo/content/posts/podcast-339.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 339"
 date = "2014-07-06T15:48:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp339.jpg"
+filename = "ump_podcast339"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp339.jpg)

--- a/hugo/content/posts/podcast-34.md
+++ b/hugo/content/posts/podcast-34.md
@@ -2,6 +2,7 @@
 title = "Выпуск 34"
 date = "2005-11-21T09:21:00"
 categories = ["podcast"]
+filename = "ump_podcast34"
 +++
 
 

--- a/hugo/content/posts/podcast-340.md
+++ b/hugo/content/posts/podcast-340.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 340"
 date = "2014-08-03T20:06:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp340.jpg"
+filename = "ump_podcast340"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp340.jpg)

--- a/hugo/content/posts/podcast-341.md
+++ b/hugo/content/posts/podcast-341.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 341"
 date = "2014-09-01T19:10:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp341.jpg"
+filename = "ump_podcast341"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp341.jpg)

--- a/hugo/content/posts/podcast-342.md
+++ b/hugo/content/posts/podcast-342.md
@@ -3,6 +3,7 @@ title = "UWP - Выпуск 342"
 date = "2014-09-28T16:25:00"
 categories = ["podcast"]
 image = "http://podcast.umputun.com/images/uwp/uwp342.jpg"
+filename = "ump_podcast342"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp342.jpg)

--- a/hugo/content/posts/podcast-35.md
+++ b/hugo/content/posts/podcast-35.md
@@ -2,6 +2,7 @@
 title = "Выпуск 35"
 date = "2005-11-24T10:51:00"
 categories = ["podcast"]
+filename = "ump_podcast35"
 +++
 
 

--- a/hugo/content/posts/podcast-36.md
+++ b/hugo/content/posts/podcast-36.md
@@ -2,6 +2,7 @@
 title = "Выпуск 36"
 date = "2005-11-28T17:39:00"
 categories = ["podcast"]
+filename = "ump_podcast36"
 +++
 
 

--- a/hugo/content/posts/podcast-37.md
+++ b/hugo/content/posts/podcast-37.md
@@ -2,6 +2,7 @@
 title = "Выпуск 37"
 date = "2005-12-02T18:44:00"
 categories = ["podcast"]
+filename = "ump_podcast37"
 +++
 
 

--- a/hugo/content/posts/podcast-38.md
+++ b/hugo/content/posts/podcast-38.md
@@ -2,6 +2,7 @@
 title = "Выпуск 38"
 date = "2005-12-06T17:31:00"
 categories = ["podcast"]
+filename = "ump_podcast38"
 +++
 
 

--- a/hugo/content/posts/podcast-39.md
+++ b/hugo/content/posts/podcast-39.md
@@ -2,6 +2,7 @@
 title = "Выпуск 39"
 date = "2005-12-09T18:36:00"
 categories = ["podcast"]
+filename = "ump_podcast39"
 +++
 
 

--- a/hugo/content/posts/podcast-4.md
+++ b/hugo/content/posts/podcast-4.md
@@ -2,6 +2,7 @@
 title = "Выпуск 4"
 date = "2005-08-06T16:09:00"
 categories = ["podcast"]
+filename = "ump_podcast4"
 +++
 
 

--- a/hugo/content/posts/podcast-40.md
+++ b/hugo/content/posts/podcast-40.md
@@ -2,6 +2,7 @@
 title = "Выпуск 40"
 date = "2005-12-13T17:13:00"
 categories = ["podcast"]
+filename = "ump_podcast40"
 +++
 
 

--- a/hugo/content/posts/podcast-41.md
+++ b/hugo/content/posts/podcast-41.md
@@ -2,6 +2,7 @@
 title = "Выпуск 41"
 date = "2005-12-17T18:07:00"
 categories = ["podcast"]
+filename = "ump_podcast41"
 +++
 
 

--- a/hugo/content/posts/podcast-42.md
+++ b/hugo/content/posts/podcast-42.md
@@ -2,6 +2,7 @@
 title = "Выпуск 42"
 date = "2005-12-21T18:06:00"
 categories = ["podcast"]
+filename = "ump_podcast42"
 +++
 
 

--- a/hugo/content/posts/podcast-44.md
+++ b/hugo/content/posts/podcast-44.md
@@ -2,6 +2,7 @@
 title = "Выпуск 44"
 date = "2005-12-30T03:12:00"
 categories = ["podcast"]
+filename = "ump_podcast44"
 +++
 
 

--- a/hugo/content/posts/podcast-45.md
+++ b/hugo/content/posts/podcast-45.md
@@ -2,6 +2,7 @@
 title = "Выпуск 45"
 date = "2006-01-02T15:51:00"
 categories = ["podcast"]
+filename = "ump_podcast45"
 +++
 
 

--- a/hugo/content/posts/podcast-46.md
+++ b/hugo/content/posts/podcast-46.md
@@ -2,6 +2,7 @@
 title = "Выпуск 46"
 date = "2006-01-07T11:39:00"
 categories = ["podcast"]
+filename = "ump_podcast46"
 +++
 
 

--- a/hugo/content/posts/podcast-47.md
+++ b/hugo/content/posts/podcast-47.md
@@ -2,6 +2,7 @@
 title = "Выпуск 47"
 date = "2006-01-11T06:15:00"
 categories = ["podcast"]
+filename = "ump_podcast47"
 +++
 
 

--- a/hugo/content/posts/podcast-48.md
+++ b/hugo/content/posts/podcast-48.md
@@ -2,6 +2,7 @@
 title = "Выпуск 48"
 date = "2006-01-15T22:06:00"
 categories = ["podcast"]
+filename = "ump_podcast48"
 +++
 
 

--- a/hugo/content/posts/podcast-49.md
+++ b/hugo/content/posts/podcast-49.md
@@ -2,6 +2,7 @@
 title = "Выпуск 49"
 date = "2006-01-20T20:55:00"
 categories = ["podcast"]
+filename = "ump_podcast49"
 +++
 
 

--- a/hugo/content/posts/podcast-50.md
+++ b/hugo/content/posts/podcast-50.md
@@ -2,6 +2,7 @@
 title = "Выпуск 50"
 date = "2006-01-25T20:55:00"
 categories = ["podcast"]
+filename = "ump_podcast50"
 +++
 
 

--- a/hugo/content/posts/podcast-51.md
+++ b/hugo/content/posts/podcast-51.md
@@ -2,6 +2,7 @@
 title = "Выпуск 51"
 date = "2006-01-29T16:34:00"
 categories = ["podcast"]
+filename = "ump_podcast51"
 +++
 
 

--- a/hugo/content/posts/podcast-52.md
+++ b/hugo/content/posts/podcast-52.md
@@ -2,6 +2,7 @@
 title = "Выпуск 52"
 date = "2006-02-01T21:34:00"
 categories = ["podcast"]
+filename = "ump_podcast52"
 +++
 
 

--- a/hugo/content/posts/podcast-53.md
+++ b/hugo/content/posts/podcast-53.md
@@ -2,6 +2,7 @@
 title = "Выпуск 53"
 date = "2006-02-06T16:38:00"
 categories = ["podcast"]
+filename = "ump_podcast53"
 +++
 
 

--- a/hugo/content/posts/podcast-54.md
+++ b/hugo/content/posts/podcast-54.md
@@ -2,6 +2,7 @@
 title = "Выпуск 54"
 date = "2006-02-11T11:27:00"
 categories = ["podcast"]
+filename = "ump_podcast54"
 +++
 
 

--- a/hugo/content/posts/podcast-55.md
+++ b/hugo/content/posts/podcast-55.md
@@ -2,6 +2,7 @@
 title = "Выпуск 55"
 date = "2006-02-16T17:46:00"
 categories = ["podcast"]
+filename = "ump_podcast55"
 +++
 
 

--- a/hugo/content/posts/podcast-56.md
+++ b/hugo/content/posts/podcast-56.md
@@ -2,6 +2,7 @@
 title = "Выпуск 56"
 date = "2006-02-20T17:44:00"
 categories = ["podcast"]
+filename = "ump_podcast56"
 +++
 
 

--- a/hugo/content/posts/podcast-57.md
+++ b/hugo/content/posts/podcast-57.md
@@ -2,6 +2,7 @@
 title = "Выпуск 57"
 date = "2006-02-25T15:24:00"
 categories = ["podcast"]
+filename = "ump_podcast57"
 +++
 
 

--- a/hugo/content/posts/podcast-58.md
+++ b/hugo/content/posts/podcast-58.md
@@ -2,6 +2,7 @@
 title = "Выпуск 58"
 date = "2006-03-02T20:21:00"
 categories = ["podcast"]
+filename = "ump_podcast58"
 +++
 
 

--- a/hugo/content/posts/podcast-59.md
+++ b/hugo/content/posts/podcast-59.md
@@ -2,6 +2,7 @@
 title = "Выпуск 59"
 date = "2006-03-07T17:35:00"
 categories = ["podcast"]
+filename = "ump_podcast59"
 +++
 
 

--- a/hugo/content/posts/podcast-6.md
+++ b/hugo/content/posts/podcast-6.md
@@ -2,6 +2,7 @@
 title = "Выпуск 6"
 date = "2005-08-09T13:11:00"
 categories = ["podcast"]
+filename = "ump_podcast6"
 +++
 
 

--- a/hugo/content/posts/podcast-60.md
+++ b/hugo/content/posts/podcast-60.md
@@ -2,6 +2,7 @@
 title = "Выпуск 60"
 date = "2006-03-12T16:07:00"
 categories = ["podcast"]
+filename = "ump_podcast60"
 +++
 
 

--- a/hugo/content/posts/podcast-61.md
+++ b/hugo/content/posts/podcast-61.md
@@ -2,6 +2,7 @@
 title = "Выпуск 61"
 date = "2006-03-16T19:32:00"
 categories = ["podcast"]
+filename = "ump_podcast61"
 +++
 
 

--- a/hugo/content/posts/podcast-62.md
+++ b/hugo/content/posts/podcast-62.md
@@ -2,6 +2,7 @@
 title = "Выпуск 62"
 date = "2006-03-22T21:20:00"
 categories = ["podcast"]
+filename = "ump_podcast62"
 +++
 
 

--- a/hugo/content/posts/podcast-63.md
+++ b/hugo/content/posts/podcast-63.md
@@ -2,6 +2,7 @@
 title = "Выпуск 63"
 date = "2006-03-28T19:50:00"
 categories = ["podcast"]
+filename = "ump_podcast63"
 +++
 
 

--- a/hugo/content/posts/podcast-64.md
+++ b/hugo/content/posts/podcast-64.md
@@ -2,6 +2,7 @@
 title = "Выпуск 64"
 date = "2006-04-02T18:03:00"
 categories = ["podcast"]
+filename = "ump_podcast64"
 +++
 
 

--- a/hugo/content/posts/podcast-65.md
+++ b/hugo/content/posts/podcast-65.md
@@ -2,6 +2,7 @@
 title = "Выпуск 65"
 date = "2006-04-07T16:43:00"
 categories = ["podcast"]
+filename = "ump_podcast65"
 +++
 
 

--- a/hugo/content/posts/podcast-66.md
+++ b/hugo/content/posts/podcast-66.md
@@ -2,6 +2,7 @@
 title = "Выпуск 66"
 date = "2006-04-12T21:25:00"
 categories = ["podcast"]
+filename = "ump_podcast66"
 +++
 
 

--- a/hugo/content/posts/podcast-67.md
+++ b/hugo/content/posts/podcast-67.md
@@ -2,6 +2,7 @@
 title = "Выпуск 67"
 date = "2006-04-17T20:57:00"
 categories = ["podcast"]
+filename = "ump_podcast67"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp67.jpg)

--- a/hugo/content/posts/podcast-68.md
+++ b/hugo/content/posts/podcast-68.md
@@ -2,6 +2,7 @@
 title = "Выпуск 68"
 date = "2006-04-22T20:27:00"
 categories = ["podcast"]
+filename = "ump_podcast68"
 +++
 
 

--- a/hugo/content/posts/podcast-69.md
+++ b/hugo/content/posts/podcast-69.md
@@ -2,6 +2,7 @@
 title = "Выпуск 69"
 date = "2006-04-28T14:24:00"
 categories = ["podcast"]
+filename = "ump_podcast69"
 +++
 
 

--- a/hugo/content/posts/podcast-7.md
+++ b/hugo/content/posts/podcast-7.md
@@ -2,6 +2,7 @@
 title = "Выпуск 7"
 date = "2005-08-13T13:11:00"
 categories = ["podcast"]
+filename = "ump_podcast7"
 +++
 
 

--- a/hugo/content/posts/podcast-70.md
+++ b/hugo/content/posts/podcast-70.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 70"
 date = "2006-05-05T19:25:00"
 categories = ["podcast"]
+filename = "ump_podcast70"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp70.gif)

--- a/hugo/content/posts/podcast-71.md
+++ b/hugo/content/posts/podcast-71.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 71"
 date = "2006-05-10T15:09:00"
 categories = ["podcast"]
+filename = "ump_podcast71"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp71.jpg)

--- a/hugo/content/posts/podcast-72.md
+++ b/hugo/content/posts/podcast-72.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 72"
 date = "2006-05-15T18:49:00"
 categories = ["podcast"]
+filename = "ump_podcast72"
 +++
 
 

--- a/hugo/content/posts/podcast-73.md
+++ b/hugo/content/posts/podcast-73.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 73"
 date = "2006-05-21T12:51:00"
 categories = ["podcast"]
+filename = "ump_podcast73"
 +++
 
 

--- a/hugo/content/posts/podcast-74.md
+++ b/hugo/content/posts/podcast-74.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 74"
 date = "2006-05-26T20:32:00"
 categories = ["podcast"]
+filename = "ump_podcast74"
 +++
 
 

--- a/hugo/content/posts/podcast-75.md
+++ b/hugo/content/posts/podcast-75.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 75"
 date = "2006-06-02T16:19:00"
 categories = ["podcast"]
+filename = "ump_podcast75"
 +++
 
 

--- a/hugo/content/posts/podcast-76.md
+++ b/hugo/content/posts/podcast-76.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 76"
 date = "2006-06-13T14:39:00"
 categories = ["podcast"]
+filename = "ump_podcast76"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp76.jpg)

--- a/hugo/content/posts/podcast-77.md
+++ b/hugo/content/posts/podcast-77.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 77"
 date = "2006-06-18T17:30:00"
 categories = ["podcast"]
+filename = "ump_podcast77"
 +++
 
 

--- a/hugo/content/posts/podcast-78.md
+++ b/hugo/content/posts/podcast-78.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 78"
 date = "2006-06-24T21:36:00"
 categories = ["podcast"]
+filename = "ump_podcast78"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp78.jpg)

--- a/hugo/content/posts/podcast-79.md
+++ b/hugo/content/posts/podcast-79.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 79"
 date = "2006-07-02T10:53:00"
 categories = ["podcast"]
+filename = "ump_podcast79"
 +++
 
 

--- a/hugo/content/posts/podcast-8.md
+++ b/hugo/content/posts/podcast-8.md
@@ -2,6 +2,7 @@
 title = "Выпуск 8"
 date = "2005-08-15T16:12:00"
 categories = ["podcast"]
+filename = "ump_podcast8"
 +++
 
 

--- a/hugo/content/posts/podcast-80.md
+++ b/hugo/content/posts/podcast-80.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 80"
 date = "2006-07-05T17:10:00"
 categories = ["podcast"]
+filename = "ump_podcast80"
 +++
 
 - Юбилей, однако

--- a/hugo/content/posts/podcast-81.md
+++ b/hugo/content/posts/podcast-81.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 81"
 date = "2006-07-12T17:10:00"
 categories = ["podcast"]
+filename = "ump_podcast81"
 +++
 
 - Неожиданная "покупка"

--- a/hugo/content/posts/podcast-82.md
+++ b/hugo/content/posts/podcast-82.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 82"
 date = "2006-07-18T17:10:00"
 categories = ["podcast"]
+filename = "ump_podcast82"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp82.jpg)

--- a/hugo/content/posts/podcast-83.md
+++ b/hugo/content/posts/podcast-83.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 83"
 date = "2006-07-22T17:10:00"
 categories = ["podcast"]
+filename = "ump_podcast83"
 +++
 
 

--- a/hugo/content/posts/podcast-84.md
+++ b/hugo/content/posts/podcast-84.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 84"
 date = "2006-08-01T16:58:00"
 categories = ["podcast"]
+filename = "ump_podcast84"
 +++
 
 

--- a/hugo/content/posts/podcast-85.md
+++ b/hugo/content/posts/podcast-85.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 85"
 date = "2006-08-09T16:51:00"
 categories = ["podcast"]
+filename = "ump_podcast85"
 +++
 
 

--- a/hugo/content/posts/podcast-86.md
+++ b/hugo/content/posts/podcast-86.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 86"
 date = "2006-08-15T19:21:00"
 categories = ["podcast"]
+filename = "ump_podcast86"
 +++
 
 - эксперименты и их результаты

--- a/hugo/content/posts/podcast-87.md
+++ b/hugo/content/posts/podcast-87.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 87"
 date = "2006-08-22T21:26:00"
 categories = ["podcast"]
+filename = "ump_podcast87"
 +++
 
 

--- a/hugo/content/posts/podcast-89.md
+++ b/hugo/content/posts/podcast-89.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 89"
 date = "2006-09-06T16:37:00"
 categories = ["podcast"]
+filename = "ump_podcast89"
 +++
 
 

--- a/hugo/content/posts/podcast-9.md
+++ b/hugo/content/posts/podcast-9.md
@@ -2,6 +2,7 @@
 title = "Выпуск 9"
 date = "2005-08-19T11:13:00"
 categories = ["podcast"]
+filename = "ump_podcast9"
 +++
 
 

--- a/hugo/content/posts/podcast-90.md
+++ b/hugo/content/posts/podcast-90.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 90"
 date = "2006-09-13T17:58:00"
 categories = ["podcast"]
+filename = "ump_podcast90"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp90.jpg)

--- a/hugo/content/posts/podcast-91.md
+++ b/hugo/content/posts/podcast-91.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 91"
 date = "2006-09-21T11:11:00"
 categories = ["podcast"]
+filename = "ump_podcast91"
 +++
 
 

--- a/hugo/content/posts/podcast-92.md
+++ b/hugo/content/posts/podcast-92.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 92"
 date = "2006-09-28T16:09:00"
 categories = ["podcast"]
+filename = "ump_podcast92"
 +++
 
 - Дилема: закуска или интернет

--- a/hugo/content/posts/podcast-93.md
+++ b/hugo/content/posts/podcast-93.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 93"
 date = "2006-10-04T16:20:00"
 categories = ["podcast"]
+filename = "ump_podcast93"
 +++
 
 

--- a/hugo/content/posts/podcast-94.md
+++ b/hugo/content/posts/podcast-94.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 94"
 date = "2006-10-11T18:00:00"
 categories = ["podcast"]
+filename = "ump_podcast94"
 +++
 
 

--- a/hugo/content/posts/podcast-95.md
+++ b/hugo/content/posts/podcast-95.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 95"
 date = "2006-10-18T16:22:00"
 categories = ["podcast"]
+filename = "ump_podcast95"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp95.jpg)

--- a/hugo/content/posts/podcast-96.md
+++ b/hugo/content/posts/podcast-96.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 96"
 date = "2006-10-25T17:30:00"
 categories = ["podcast"]
+filename = "ump_podcast96"
 +++
 
 

--- a/hugo/content/posts/podcast-97.md
+++ b/hugo/content/posts/podcast-97.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 97"
 date = "2006-11-01T16:53:00"
 categories = ["podcast"]
+filename = "ump_podcast97"
 +++
 
 

--- a/hugo/content/posts/podcast-98.md
+++ b/hugo/content/posts/podcast-98.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 98"
 date = "2006-11-09T20:36:00"
 categories = ["podcast"]
+filename = "ump_podcast98"
 +++
 
 

--- a/hugo/content/posts/podcast-99.md
+++ b/hugo/content/posts/podcast-99.md
@@ -2,6 +2,7 @@
 title = "UWP - Выпуск 99"
 date = "2006-11-16T10:02:00"
 categories = ["podcast"]
+filename = "ump_podcast99"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/uwp99.JPG)

--- a/hugo/content/posts/podcast-ypp.md
+++ b/hugo/content/posts/podcast-ypp.md
@@ -2,6 +2,7 @@
 title = "Я в гостях у Димы"
 date = "2012-10-15T12:35:00"
 categories = ["others"]
+filename = "yp682"
 +++
 
 ![](https://podcast.umputun.com/images/uwp/yppandump.jpg)

--- a/hugo/data/rss/archives.xml
+++ b/hugo/data/rss/archives.xml
@@ -5,7 +5,7 @@
               <title><![CDATA[{title}]]></title>
               <link>{url}</link>
               <description>Архивы UWP</description>
-              <enclosure url="http://archive.rucast.net/uwp/media/{filename}.mp3" type="audio/mpeg"/>
-              <guid isPermaLink="false">http://archive.rucast.net/uwp/media/{filename}.mp3</guid>
+              <enclosure url="{filename}" type="audio/mpeg"/>
+              <guid isPermaLink="false">{filename}</guid>
               <pubDate>{date}</pubDate>
             </item>

--- a/hugo/data/rss/podcast-archives-short.xml
+++ b/hugo/data/rss/podcast-archives-short.xml
@@ -7,5 +7,5 @@
       <itunes:author><![CDATA[Umputun]]></itunes:author>
       <itunes:summary></itunes:summary>
       <itunes:image href="{image}" />
-      <enclosure url="http://archive.rucast.net/uwp/media/{filename}.mp3" type="audio/mp3" />
+      <enclosure url="{filename}" type="audio/mp3" />
     </item>

--- a/hugo/data/rss/podcast-failback.xml
+++ b/hugo/data/rss/podcast-failback.xml
@@ -7,5 +7,5 @@
         <itunes:author><![CDATA[Umputun]]></itunes:author>
         <itunes:summary><![CDATA[{text}]]></itunes:summary>
         <itunes:image href="{image}" />
-        <enclosure url="http://podcast-failback.umputun.com/media/{filename}.mp3" length="{filesize}" type="audio/mp3"/>
+        <enclosure url="{filename}" length="{filesize}" type="audio/mp3"/>
     </item>

--- a/hugo/data/rss/podcast.xml
+++ b/hugo/data/rss/podcast.xml
@@ -7,6 +7,6 @@
       <itunes:author><![CDATA[Umputun]]></itunes:author>
       <itunes:summary><![CDATA[{text}]]></itunes:summary>
       <itunes:image href="{image}" />
-      <enclosure url="https://podcast.umputun.com/media/{filename}.mp3" length="{filesize}" type="audio/mp3"/>
+      <enclosure url="{filename}" length="{filesize}" type="audio/mp3"/>
     </item>
 


### PR DESCRIPTION
фикс для #32 
Теперь урл берется из \<audio> тэга.

Сначала думал, что можно просто везде добавить filename в каждый выпуск, но это не решило проблемы со гостевыми выпусками.

Идеально наверное было бы просто ставить полную ссылку на мп3 в конфиг поста, а уже в темплейте её потом вставлять в хтмл.

Заодно заметил, что у выпусков с ЯПП и у подкаста с CTOCast битые ссылки.